### PR TITLE
Mark BytesMut::extend_from_slice as inline

### DIFF
--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -438,13 +438,7 @@ impl BytesMut {
 
     /// Resizes the buffer so that `len` is equal to `new_len`.
     ///
-    /// If `new_len` is greater than `len`, the buffer is 
-    
-    
-    
-    
-    
-    ed by the
+    /// If `new_len` is greater than `len`, the buffer is extended by the
     /// difference with each additional byte set to `value`. If `new_len` is
     /// less than `len`, the buffer is simply truncated.
     ///

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -438,7 +438,13 @@ impl BytesMut {
 
     /// Resizes the buffer so that `len` is equal to `new_len`.
     ///
-    /// If `new_len` is greater than `len`, the buffer is extended by the
+    /// If `new_len` is greater than `len`, the buffer is 
+    
+    
+    
+    
+    
+    ed by the
     /// difference with each additional byte set to `value`. If `new_len` is
     /// less than `len`, the buffer is simply truncated.
     ///
@@ -761,6 +767,7 @@ impl BytesMut {
     ///
     /// assert_eq!(b"aaabbbcccddd", &buf[..]);
     /// ```
+    #[inline]
     pub fn extend_from_slice(&mut self, extend: &[u8]) {
         let cnt = extend.len();
         self.reserve(cnt);


### PR DESCRIPTION
`BytesMut::extend_from_slice `, `<BytesMut as BufMut>::put_u8` and `<BytesMut as BufMut>::put_slice` can be bottlenecks when encoding certain messages. This PR just marks extend_from_slice as inline since it is probably an easier change to accept.

example benchmark with these changes applied. Involves encoding a struct in ASN.1 
```
$ hyperfine ./target/release/benchber ./target/release/benchber.orig 
Benchmark 1: ./target/release/benchber
  Time (mean ± σ):      1.179 s ±  0.067 s    [User: 0.937 s, System: 0.226 s]
  Range (min … max):    1.055 s …  1.257 s    10 runs
 
Benchmark 2: ./target/release/benchber.orig
  Time (mean ± σ):      1.935 s ±  0.101 s    [User: 1.686 s, System: 0.233 s]
  Range (min … max):    1.795 s …  2.159 s    10 runs

Summary
  './target/release/benchber' ran
    1.64 ± 0.13 times faster than './target/release/benchber.orig
```